### PR TITLE
Make the title not do funny things on extremely large screens

### DIFF
--- a/blah/header.css
+++ b/blah/header.css
@@ -38,7 +38,7 @@
             display:  flex;
         }
         #title {
-            font-size: calc(14vw - 20px);
+            font-size: calc(min(256px, 14vw - 20px));
             position:  relative;
         }
         #logo {


### PR DESCRIPTION
Previously the title would end up with a font size that falls off screen if you view it full width on a 4k monitor at 1x scale.

Previously:
![image](https://user-images.githubusercontent.com/6652840/162644191-18c44e7b-3ec7-4ed9-a239-08daeba3a2a8.png)


Now:
![Screenshot_20220410_161920](https://user-images.githubusercontent.com/6652840/162644194-15aceabe-9f30-4331-aad2-fe5009410a3c.png)
